### PR TITLE
Fix docker compose stack

### DIFF
--- a/docker/appconfig-frontend.yml
+++ b/docker/appconfig-frontend.yml
@@ -1,15 +1,11 @@
-version: "3.8"
-
 services:
   app-config-frontend:
       build:
         context: ../radar-app-config-frontend
       #    image: radarbase/radar-app-config-frontend:dev
       environment:
-        - AUTH_URL=http://127.0.0.1:8080/managementportal/oauth
+        - AUTH_URL=http://127.0.0.1:8080/managementportal/oauth2
         - AUTH_CALLBACK_URL=http://127.0.0.1:8080/appconfig/login
-      depends_on:
-        - app-config
       labels:
         - "traefik.http.routers.appconfigfrontend.rule=PathPrefix(`/appconfig`)"
         - "traefik.http.services.appconfigfrontend.loadbalancer.server.port=8080"

--- a/docker/appconfig_local/docker-compose.yml
+++ b/docker/appconfig_local/docker-compose.yml
@@ -1,6 +1,4 @@
 # start the dockerstack using a locally built docker image of app-config.
-version: "3.8"
-
 include:
   - "../non_appconfig/docker-compose.yml"
 
@@ -9,13 +7,16 @@ services:
     extends:
       file: ../appconfig.yml
       service: app-config
+    depends_on:
+      - traefik
     networks:
-      - db
       - default
 
   app-config-frontend:
     extends:
       file: ../appconfig-frontend.yml
       service: app-config-frontend
+    depends_on:
+      - traefik
     networks:
       - default

--- a/docker/etc/mp-config/kratos/kratos.yml
+++ b/docker/etc/mp-config/kratos/kratos.yml
@@ -12,7 +12,7 @@ serve:
     base_url: http://kratos:4434/
 
 selfservice:
-  default_browser_return_url: http://127.0.0.1:3000/
+  default_browser_return_url: http://127.0.0.1:8080/kratos-ui/
   allowed_return_urls:
     - http://127.0.0.1:3000/
     - http://127.0.0.1:8081/
@@ -21,23 +21,23 @@ selfservice:
   methods:
     password:
       enabled: true
-    oidc:
-      config:
-        providers:
-          # social sign-in for google. This needs to be tied to a google account. values below were added by bastiaan
-          - id: google_d292689d # this is `<provider-id>` in the Authorization callback URL. DO NOT CHANGE IT ONCE SET! current google callback: http://127.0.0.1:4433/self-service/methods/oidc/callback/google_d292689d
-            provider: google
-            client_id: 922854293804-r3fhl9tom6uutcq5c8fm4592l1t6s3mh.apps.googleusercontent.com # Replace this with the Client ID
-            client_secret: # Replace this with the Client secret
-            issuer_url: https://accounts.google.com # Replace this with the providers issuer URL
-            mapper_url: "base64://bG9jYWwgY2xhaW1zID0gewogIGVtYWlsX3ZlcmlmaWVkOiBmYWxzZSwKfSArIHN0ZC5leHRWYXIoJ2NsYWltcycpOwoKewogIGlkZW50aXR5OiB7CiAgICB0cmFpdHM6IHsKICAgICAgW2lmICdlbWFpbCcgaW4gY2xhaW1zICYmIGNsYWltcy5lbWFpbF92ZXJpZmllZCB0aGVuICdlbWFpbCcgZWxzZSBudWxsXTogY2xhaW1zLmVtYWlsLAogICAgfSwKICB9LAp9"
-            # currently: GitHub example from: https://www.ory.sh/docs/kratos/social-signin/data-mapping
-            # Alternatively, use an URL:
-            # mapper_url: https://storage.googleapis.com/abc-cde-prd/9cac9717f007808bf17
-            scope:
-              - email
-            # supported scopes can be found in your providers dev docs
-      enabled: true
+#    oidc:
+#      config:
+#        providers:
+#          # social sign-in for google. This needs to be tied to a google account. values below were added by bastiaan
+#          - id: google_d292689d # this is `<provider-id>` in the Authorization callback URL. DO NOT CHANGE IT ONCE SET! current google callback: http://127.0.0.1:4433/self-service/methods/oidc/callback/google_d292689d
+#            provider: google
+#            client_id: 922854293804-r3fhl9tom6uutcq5c8fm4592l1t6s3mh.apps.googleusercontent.com # Replace this with the Client ID
+#            client_secret: # Replace this with the Client secret
+#            issuer_url: https://accounts.google.com # Replace this with the providers issuer URL
+#            mapper_url: "base64://bG9jYWwgY2xhaW1zID0gewogIGVtYWlsX3ZlcmlmaWVkOiBmYWxzZSwKfSArIHN0ZC5leHRWYXIoJ2NsYWltcycpOwoKewogIGlkZW50aXR5OiB7CiAgICB0cmFpdHM6IHsKICAgICAgW2lmICdlbWFpbCcgaW4gY2xhaW1zICYmIGNsYWltcy5lbWFpbF92ZXJpZmllZCB0aGVuICdlbWFpbCcgZWxzZSBudWxsXTogY2xhaW1zLmVtYWlsLAogICAgfSwKICB9LAp9"
+#            # currently: GitHub example from: https://www.ory.sh/docs/kratos/social-signin/data-mapping
+#            # Alternatively, use an URL:
+#            # mapper_url: https://storage.googleapis.com/abc-cde-prd/9cac9717f007808bf17
+#            scope:
+#              - email
+#            # supported scopes can be found in your providers dev docs
+#      enabled: true
     totp:
       config:
         issuer: Kratos
@@ -47,34 +47,34 @@ selfservice:
 
   flows:
     error:
-      ui_url: http://127.0.0.1:3000/error
+      ui_url: http://127.0.0.1:8080/kratos-ui/error
 
     settings:
-      ui_url: http://127.0.0.1:3000/settings
+      ui_url: http://127.0.0.1:8080/kratos-ui/settings
 
     recovery:
       enabled: true
-      ui_url: http://127.0.0.1:3000/recovery
+      ui_url: http://127.0.0.1:8080/kratos-ui/recovery
       use: link
 
     verification:
       # our current flow necessitates that users reset their password after they activate an account in managementportal,
       # this works as verification
-      ui_url: http://127.0.0.1:3000/verification
+      ui_url: http://127.0.0.1:8080/kratos-ui/verification
       enabled: true
       use: link
       after:
-        default_browser_return_url: http://127.0.0.1:3000
+        default_browser_return_url: http://127.0.0.1:8080/kratos-ui
 
     logout:
       after:
-        default_browser_return_url: http://127.0.0.1:3000/login
+        default_browser_return_url: http://127.0.0.1:8080/kratos-ui/login
 
     login:
-      ui_url: http://127.0.0.1:3000/login
+      ui_url: http://127.0.0.1:8080/kratos-ui/login
 
     registration:
-      ui_url: http://127.0.0.1:3000/registration
+      ui_url: http://127.0.0.1:8080/kratos-ui/registration
       after:
         password:
           hooks:

--- a/docker/managementportal.yml
+++ b/docker/managementportal.yml
@@ -1,10 +1,10 @@
-version: "3.8"
-
 services:
   managementportal:
-    image: radarbase/management-portal:2.1.0
+    image: radarbase/management-portal:dev
     environment:
-      MANAGEMENTPORTAL_IDENTITYSERVER_SERVERURL: http://kratos
+      MANAGEMENTPORTAL_IDENTITYSERVER_SERVERURL: http://kratos:4433
+      MANAGEMENTPORTAL_IDENTITYSERVER_SERVERADMINURL: http://kratos:4434
+      MANAGEMENTPORTAL_IDENTITYSERVER_LOGINURL: http://127.0.0.1:8080/kratos-ui
       MANAGEMENTPORTAL_IDENTITYSERVER_ADMINEMAIL: bastiaan@thehyve.nl
       MANAGEMENTPORTAL_OAUTH_REQUIREAAL2: false
       SPRING_LIQUIBASE_CONTEXTS: dev #includes testing_data, remove for production builds
@@ -13,7 +13,7 @@ services:
       SPRING_DATASOURCE_USERNAME: radarcns
       SPRING_DATASOURCE_PASSWORD: radarcns
       MANAGEMENTPORTAL_FRONTEND_CLIENT_SECRET: "testMe"
-      MANAGEMENTPORTAL_COMMON_BASE_URL: http://localhost:8080/managementportal
+      MANAGEMENTPORTAL_COMMON_BASE_URL: http://localhost:8080
       MANAGEMENTPORTAL_COMMON_MANAGEMENT_PORTAL_BASE_URL: http://localhost:8080/managementportal
       MANAGEMENTPORTAL_OAUTH_CLIENTS_FILE: /mp-includes/config/oauth_client_details.csv
       MANAGEMENTPORTAL_CATALOGUE_SERVER_ENABLE_AUTO_IMPORT: 'false'

--- a/docker/non_appconfig/docker-compose.yml
+++ b/docker/non_appconfig/docker-compose.yml
@@ -1,7 +1,5 @@
 # Docker stack containing all the "required" interacting components to run app-config
 # Intended to use alongside local executables of app-config (e.g. in an  Intellij instance) for development/debug purposes
-version: "3.8"
-
 networks:
   db:
     driver: bridge
@@ -41,8 +39,12 @@ services:
     extends:
       file: ../managementportal.yml
       service: managementportal
+    depends_on:
+      - kratos
+      - traefik
     networks:
       - mp
+#      - ory
       - default
 
   managementportal-postgresql:
@@ -51,12 +53,17 @@ services:
       service: postgres
     networks:
       - mp
+#      - default
+#    ports:
+#      - "5432:5432"
 
 
   kratos-selfservice-ui-node:
     extends:
       file: ../ory_stack.yml
       service: kratos-selfservice-ui-node
+    depends_on:
+      - traefik
     networks:
       - ory
       - default
@@ -67,6 +74,7 @@ services:
       service: kratos
     networks:
       - ory
+      - mp
       - default
 
   kratos-migrate:

--- a/docker/ory_stack.yml
+++ b/docker/ory_stack.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   kratos-selfservice-ui-node:
     image:
@@ -13,8 +11,10 @@ services:
       - COOKIE_SECRET=unsafe_cookie_secret
       - CSRF_COOKIE_NAME=radar
       - CSRF_COOKIE_SECRET=unsafe_csrf_cookie_secret
-    ports:
-      - "3000:3000"
+      - BASE_PATH=/kratos-ui
+    labels:
+      - "traefik.http.routers.kratosselfserviceuinode.rule=PathPrefix(`/kratos-ui`)"
+      - "traefik.http.services.kratosselfserviceuinode.loadbalancer.server.port=3000"
     volumes:
       - /tmp/ui-node/logs:/root/.npm/_logs
 


### PR DESCRIPTION
adding support for interaction with managementportal using ory identities

If the managementportal is set to an old version, and the auth_url is set to `/oauth` instead of `/oauth2` everything still functions as it did previously